### PR TITLE
Fix heading id attribute

### DIFF
--- a/src/modules/header/index.ts
+++ b/src/modules/header/index.ts
@@ -4,6 +4,6 @@ import './index.css';
 
 export function header ({ data }: Props<HeaderBlock>) {
   const { anchor, level, text } = data;
-  const item = `<h${level} class="ce-header" id="${anchor}">${text}</h${level}>`;
+  const item = `<h${level} class="ce-header" ${anchor ? `id="${anchor}"` : ''}>${text}</h${level}>`;
   return baseBlock(item);
 }


### PR DESCRIPTION
Fixing the addition of an empty id if no anchor is specified for the heading. 
<img width="343" alt="Screenshot 2023-07-29 at 20 30 40" src="https://github.com/vorjyga/editorjs-to-html/assets/104063733/a7039237-b9a6-47f0-954f-5a25f2fccdb2">


You can verify that an empty id is invalid by following the [w3c validator](https://validator.w3.org/nu/#textarea)